### PR TITLE
Fix: Muda titulo do evento

### DIFF
--- a/themes/quebradev/layout/_partial/conferencia-tecnologia-e-sociedade-2.ejs
+++ b/themes/quebradev/layout/_partial/conferencia-tecnologia-e-sociedade-2.ejs
@@ -33,10 +33,65 @@
             </div>
         </div>
 
+        <div class="event col-6">
+            <h3>Credenciamento</h3>
+            <p><strong>Horário:</strong> 10hrs</p>
+            <p><strong>Conteúdo:</strong> Abertura do Credenciamento e Cafézinho</p>
+        </div>
+        <div class="event col-6">
+            <h3>Abertura da Conferência</h3>
+            <p><strong>Horário:</strong> 10h20m até 10h30m</p>
+            <p><strong>Conteúdo:</strong> Abertura da Conferência com Falas Inicias do QuebraDev</p>
+        </div>
+
+        <div class="event col-6">
+            <h3>Artigo | Observatório do Santo Amaro Iniciativa Crucial para a Comunicação Social e Inclusão Digital nas Favelas</h3>
+            <p><strong>Horário:</strong> 10h30m até 10h50m</p>
+            <p><strong>Por:</strong> Lucas da Silva Alves Pessoa</p>
+        </div>
+        <div class="event col-6">
+            <h3>Palestra | Como eu ensino programação para meninas na Brasilândia</h3>
+            <p><strong>Horário:</strong> 11h00m até 11h35m</p>
+            <p><strong>Por:</strong> Larissa Vitoriano</p>
+        </div>
+
+        <div class="event col-6">
+            <h3>Artigo | TBC-DTW: Medição automática de viés midiático baseada em modelagem de tópicos</h3>
+            <p><strong>Horário:</strong> 11h40m até 12h00m</p>
+            <p><strong>Por:</strong> Daniel Pereira Zitei</p>
+        </div>
+        <div class="event col-6">
+            <h3>Almoço e Coffe Break</h3>
+            <p><strong>Horário:</strong> 12h00m até 13h20m</p>
+            <p><strong>Por:</strong> Teremos coffe break gratuito com opções veganas, restaurante no local com pagamento a parte e restaurantes nas redondezas com preço justo.</p>
+        </div>
+
+        <div class="event col-6">
+            <h3>Artigo | Assinatura do Genocídio nos dados de mortes em Gaza.</h3>
+            <p><strong>Horário:</strong> 13h20m até 13h40m</p>
+            <p><strong>Por:</strong> Henrique Xavier</p>
+        </div>
+        <div class="event col-6">
+            <h3>Mesa | O uso das redes sociais e da mídia para o avanço da esquerda e das ideias preogressistas</h3>
+            <p><strong>Horário:</strong> 13h45m até 14h45m</p>
+            <p><strong>Por:</strong> Moderador: Júnior Rocha, participantes: Veronyka Gimenes do Código Não Binário e Normose</p>
+        </div>
+
+        <div class="event col-6">
+            <h3>Artigo | Subvertendo Algoritmos e Sistemas de Controle.</h3>
+            <p><strong>Horário:</strong> 14h50m até 15h10m</p>
+            <p><strong>Por:</strong> Maria Alice Silva Santos Felix</p>
+        </div>
+        <div class="event col-6">
+            <h3>Palestra | Encruzilhadas da educação tecnológica no Brasil: Desafios e caminhos para uma educação tecnológica popular e contra colonial.</h3>
+            <p><strong>Horário:</strong> 15h15m até 15h50m</p>
+            <p><strong>Por:</strong> Moderador: Marcela da Silva Canto Bastos</p>
+        </div>
+
         <div class="event col-12">
-            <h3>Em breve</h3>
-            <p><strong>Horário:</strong> 09hrs</p>
-            <p><strong>Conteúdo:</strong> Em breve</p>
+            <h3>Agradecimentos e Encerramento.</h3>
+            <p><strong>Horário:</strong> 15h50m até 16h00m</p>
+            <p><strong>Por:</strong> @quebradev</p>
         </div>
     </div>
 

--- a/themes/quebradev/layout/_partial/conferencia-tecnologia-e-sociedade-2.ejs
+++ b/themes/quebradev/layout/_partial/conferencia-tecnologia-e-sociedade-2.ejs
@@ -3,7 +3,7 @@
         <div class="col-12 text-center">
             <h1>Conferência Tecnologia e Sociedade</h1>
             <div class="subtitle">
-                <p>Tecnologia para todos!</p>
+                <p>Tecnologia para todas pessoas!</p>
             </div>
         </div>
     </div>
@@ -12,7 +12,7 @@
         <div class="col-12 social text-left">
             <h3>Descrição</h3>
             <p>Na edição passada, fizemos a pergunta: Tecnologia para Quem? Com isso, trouxemos diversas pessoas para desafiar a ideia de que a tecnologia deve servir apenas a propósitos mercadológicos, trazendo o debate para a esfera do uso da tecnologia em benefício das comunidades periféricas e apresentando reflexões sobre como isso pode ser alcançado.</p>
-            <p>Nesta edição, vamos debater o tema: Tecnologia para Todos! Queremos que a produção técnico-científica da tecnologia seja pensada para todas as pessoas e que possa alcançar a todos. A ideia central é projetar e refletir sobre as possibilidades dessas tecnologias em nossos territórios, construídos pelos coletivos populares, cientistas de grupos sociais marginalizados e trabalhadores.</p>
+            <p>Nesta edição, vamos debater o tema: Tecnologia para Todas Pessoas! Queremos que a produção técnico-científica da tecnologia seja pensada para e alcançavel para todas as pessoas. A ideia central é projetar e refletir sobre as possibilidades dessas tecnologias em nossos territórios, construídos pelos coletivos populares, cientistas de grupos sociais marginalizados e trabalhadores.</p>
             <p>Esperamos que você possa contribuir e participar ativamente dessa construção e debate.</p>
             <p>
                 <b>Data:</b> 23 de Novembro de 2024 <br>


### PR DESCRIPTION
Procuramos mudar o titulo do evento pós algumas considerações externas, pois o uso da palavra todos cai exatamente no ponto de critica em que trazemos em nossa conferencia, utilizar o tecnologia para todas as pessoas agrega e bate na lógica atual do mercado de tecnologia.

Contudo, há alguns materiais e informativos que já foram impressos com esse nome, e por isso pode haver confusão no tema. Devido a isso, cabe a reflexão se mudamos ou adicionamos algumas declarações a mais salientando nosso posicionamento.