### PR TITLE
Fix: muda contexto do evento para evitar binarismo de genero

### DIFF
--- a/themes/quebradev/layout/_partial/conferencia-tecnologia-e-sociedade-2.ejs
+++ b/themes/quebradev/layout/_partial/conferencia-tecnologia-e-sociedade-2.ejs
@@ -3,7 +3,7 @@
         <div class="col-12 text-center">
             <h1>Conferência Tecnologia e Sociedade</h1>
             <div class="subtitle">
-                <p>Tecnologia para todos!</p>
+                <p>Tecnologia para todas pessoas!</p>
             </div>
         </div>
     </div>
@@ -12,7 +12,7 @@
         <div class="col-12 social text-left">
             <h3>Descrição</h3>
             <p>Na edição passada, fizemos a pergunta: Tecnologia para Quem? Com isso, trouxemos diversas pessoas para desafiar a ideia de que a tecnologia deve servir apenas a propósitos mercadológicos, trazendo o debate para a esfera do uso da tecnologia em benefício das comunidades periféricas e apresentando reflexões sobre como isso pode ser alcançado.</p>
-            <p>Nesta edição, vamos debater o tema: Tecnologia para Todos! Queremos que a produção técnico-científica da tecnologia seja pensada para todas as pessoas e que possa alcançar a todos. A ideia central é projetar e refletir sobre as possibilidades dessas tecnologias em nossos territórios, construídos pelos coletivos populares, cientistas de grupos sociais marginalizados e trabalhadores.</p>
+            <p>Nesta edição, vamos debater o tema: Tecnologia para Todas Pessoas! Queremos que a produção técnico-científica da tecnologia seja pensada para e alcançavel para todas as pessoas. A ideia central é projetar e refletir sobre as possibilidades dessas tecnologias em nossos territórios, construídos pelos coletivos populares, cientistas de grupos sociais marginalizados e trabalhadores.</p>
             <p>Esperamos que você possa contribuir e participar ativamente dessa construção e debate.</p>
             <p>
                 <b>Data:</b> 23 de Novembro de 2024 <br>


### PR DESCRIPTION
Procuramos mudar o titulo do evento pós algumas considerações externas, pois o uso da palavra todos cai exatamente no ponto de critica em que trazemos em nossa conferencia, utilizar o tecnologia para todas as pessoas agrega e bate na lógica atual do mercado de tecnologia.

Contudo, há alguns materiais e informativos que já foram impressos com esse nome, e por isso pode haver confusão no tema. Devido a isso, cabe a reflexão se mudamos ou adicionamos algumas declarações a mais salientando nosso posicionamento.